### PR TITLE
fix: svg polygons not showing up; using DOMParser for svg

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -163,7 +163,7 @@ export async function decorateIcons(element) {
           for (let i = 0; i < attributes.length; i += 1) {
             // attributes not to be transferred to the new <symbol> elem
             const skippedAttrs = ['xmlns'];
-            if (skippedAttrs.includes(attributes[i].name)) {
+            if (!skippedAttrs.includes(attributes[i].name)) {
               svgSymbol.setAttribute(attributes[i].name, attributes[i].value);
             }
           }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -149,7 +149,7 @@ export async function decorateIcons(element) {
     if (!ICONS_CACHE[iconName]) {
       ICONS_CACHE[iconName] = true;
       try {
-        const response = await fetch(`${window.hlx.codeBasePath}${window.hlx.codeBasePath}/icons/${iconName}.svg`);
+        const response = await fetch(`${window.hlx.codeBasePath}/icons/${iconName}.svg`);
         const svgSource = await response.text();
         if (svgSource.match(/(<style | class=)/)) {
           ICONS_CACHE[iconName] = { styled: true, html: svgSource };

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -161,10 +161,11 @@ export async function decorateIcons(element) {
           const { attributes } = parsedSvg.documentElement;
 
           for (let i = 0; i < attributes.length; i += 1) {
-            if(attributes[i].name === 'xmlns') { 
-              continue;
+            // attributes not to be transferred to the new <symbol> elem
+            const skippedAttrs = ['xmlns'];
+            if (skippedAttrs.includes(attributes[i].name)) {
+              svgSymbol.setAttribute(attributes[i].name, attributes[i].value);
             }
-            svgSymbol.setAttribute(attributes[i].name, attributes[i].value);
           }
 
           svgSymbol.setAttribute('id', `icons-sprite-${iconName}`);

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -156,22 +156,25 @@ export async function decorateIcons(element) {
         } else {
           const parser = new DOMParser();
           const parsedSvg = parser.parseFromString(svgSource, 'image/svg+xml');
-          const newSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+          const svgSymbol = document.createElement('symbol');
 
           const { attributes } = parsedSvg.documentElement;
 
           for (let i = 0; i < attributes.length; i += 1) {
-            newSvg.setAttribute(attributes[i].name, attributes[i].value);
+            if(attributes[i].name === 'xmlns') { 
+              continue;
+            }
+            svgSymbol.setAttribute(attributes[i].name, attributes[i].value);
           }
 
-          newSvg.setAttribute('id', iconName);
-          newSvg.removeAttribute('width');
-          newSvg.removeAttribute('height');
+          svgSymbol.setAttribute('id', `icons-sprite-${iconName}`);
+          svgSymbol.removeAttribute('width');
+          svgSymbol.removeAttribute('height');
 
-          newSvg.innerHTML = parsedSvg.documentElement.innerHTML;
+          svgSymbol.innerHTML = parsedSvg.documentElement.innerHTML;
 
           ICONS_CACHE[iconName] = {
-            html: newSvg.outerHTML,
+            html: svgSymbol.outerHTML,
           };
         }
       } catch (err) {

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -156,15 +156,16 @@ export async function decorateIcons(element) {
         } else {
           const parser = new DOMParser();
           const parsedSvg = parser.parseFromString(svgSource, 'image/svg+xml');
-          const svgSymbol = document.createElement('symbol');
+          const svgSymbol = document.createElementNS('http://www.w3.org/2000/svg', 'symbol');
 
           const { attributes } = parsedSvg.documentElement;
 
           for (let i = 0; i < attributes.length; i += 1) {
-            // attributes not to be transferred to the new <symbol> elem
-            const skippedAttrs = ['xmlns'];
-            if (!skippedAttrs.includes(attributes[i].name)) {
-              svgSymbol.setAttribute(attributes[i].name, attributes[i].value);
+            const { name, value } = attributes[i];
+
+            // remove XML namespace-related attributes
+            if (!name.startsWith('xmlns:') && name !== 'xmlns') {
+              svgSymbol.setAttribute(name, value);
             }
           }
 

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -141,32 +141,42 @@ export async function decorateIcons(element) {
   // Download all new icons
   const icons = [...element.querySelectorAll('span.icon')];
   await Promise.all(icons.map(async (span) => {
-    const iconName = Array.from(span.classList).find((c) => c.startsWith('icon-')).substring(5);
+    if (span.classList.length < 2 || !span.classList[1].startsWith('icon-')) {
+      return;
+    }
+
+    const iconName = span.classList[1].substring(5);
     if (!ICONS_CACHE[iconName]) {
       ICONS_CACHE[iconName] = true;
       try {
-        const response = await fetch(`${window.hlx.codeBasePath}/icons/${iconName}.svg`);
-        if (!response.ok) {
-          ICONS_CACHE[iconName] = false;
-          return;
-        }
-        // Styled icons don't play nice with the sprite approach because of shadow dom isolation
-        const svg = await response.text();
-        if (svg.match(/(<style | class=)/)) {
-          ICONS_CACHE[iconName] = { styled: true, html: svg };
+        const response = await fetch(`${window.hlx.codeBasePath}${window.hlx.codeBasePath}/icons/${iconName}.svg`);
+        const svgSource = await response.text();
+        if (svgSource.match(/(<style | class=)/)) {
+          ICONS_CACHE[iconName] = { styled: true, html: svgSource };
         } else {
+          const parser = new DOMParser();
+          const parsedSvg = parser.parseFromString(svgSource, 'image/svg+xml');
+          const newSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+          const { attributes } = parsedSvg.documentElement;
+
+          for (let i = 0; i < attributes.length; i += 1) {
+            newSvg.setAttribute(attributes[i].name, attributes[i].value);
+          }
+
+          newSvg.setAttribute('id', iconName);
+          newSvg.removeAttribute('width');
+          newSvg.removeAttribute('height');
+
+          newSvg.innerHTML = parsedSvg.documentElement.innerHTML;
+
           ICONS_CACHE[iconName] = {
-            html: svg
-              .replace('<svg', `<symbol id="icons-sprite-${iconName}"`)
-              .replace(/ width=".*?"/, '')
-              .replace(/ height=".*?"/, '')
-              .replace('</svg>', '</symbol>'),
+            html: newSvg.outerHTML,
           };
         }
-      } catch (error) {
-        ICONS_CACHE[iconName] = false;
+      } catch (err) {
         // eslint-disable-next-line no-console
-        console.error(error);
+        console.error(err);
       }
     }
   }));
@@ -175,13 +185,22 @@ export async function decorateIcons(element) {
   svgSprite.innerHTML += symbols;
 
   icons.forEach((span) => {
-    const iconName = Array.from(span.classList).find((c) => c.startsWith('icon-')).split('-')[1];
+    if (span.classList.length < 2 || !span.classList[1].startsWith('icon-')) {
+      return;
+    }
+
+    const iconName = span.classList[1].substring(5);
     const parent = span.firstElementChild?.tagName === 'A' ? span.firstElementChild : span;
-    // Styled icons need to be inlined as-is, while unstyled ones can leverage the sprite
     if (ICONS_CACHE[iconName].styled) {
       parent.innerHTML = ICONS_CACHE[iconName].html;
     } else {
-      parent.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg"><use href="#icons-sprite-${iconName}"/></svg>`;
+      const svgElem = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      const useElem = document.createElement('use');
+
+      useElem.setAttribute('href', `#${iconName}`);
+
+      svgElem.innerHTML = useElem.outerHTML;
+      parent.innerHTML = svgElem.outerHTML;
     }
   });
 }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -201,7 +201,7 @@ export async function decorateIcons(element) {
       const svgElem = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
       const useElem = document.createElement('use');
 
-      useElem.setAttribute('href', `#${iconName}`);
+      useElem.setAttribute('href', `#icons-sprite-${iconName}`);
 
       svgElem.innerHTML = useElem.outerHTML;
       parent.innerHTML = svgElem.outerHTML;

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -168,7 +168,6 @@ export async function decorateIcons(element) {
               svgSymbol.setAttribute(name, value);
             }
           }
-
           svgSymbol.setAttribute('id', `icons-sprite-${iconName}`);
           svgSymbol.removeAttribute('width');
           svgSymbol.removeAttribute('height');


### PR DESCRIPTION
fix: svg polygons not showing up; using DOMParser instead of regex for svg manipulation, for improved safety

Fix #191 

Test URL: https://fix-decorated-svg--helix-project-boilerplate--dicagno.hlx.page/
