### PR TITLE
Remove promise rejection from fetchPlaceholders

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -200,7 +200,7 @@ export async function fetchPlaceholders(prefix = 'default') {
   window.placeholders = window.placeholders || {};
   const loaded = window.placeholders[`${prefix}-loaded`];
   if (!loaded) {
-    window.placeholders[`${prefix}-loaded`] = new Promise((resolve, reject) => {
+    window.placeholders[`${prefix}-loaded`] = new Promise((resolve) => {
       fetch(`${prefix === 'default' ? '' : prefix}/placeholders.json`)
         .then((resp) => {
           if (resp.ok) {
@@ -218,8 +218,10 @@ export async function fetchPlaceholders(prefix = 'default') {
           resolve();
         }).catch((error) => {
           // error loading placeholders
+          // eslint-disable-next-line no-console
+          console.error('failed to fetch placeholders.', error);
           window.placeholders[prefix] = {};
-          reject(error);
+          resolve();
         });
     });
   }


### PR DESCRIPTION
fetchPlaceholders method returns an object with the items set up in placeholders.xlsx.
Unsuccessful fetching / processing of the placeholders caused an unhandled exception, the issue is fixed in this PR. 
(The exception can also be handled in the functions calling the fetchPlaceholders function, but at the moment it is not handled)

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--<repo>--<owner>.hlx.page/
- After: https://<branch>--<repo>--<owner>.hlx.page/
