### PR TITLE
feat: meta based csp

### DIFF
--- a/scripts/csp.json
+++ b/scripts/csp.json
@@ -1,0 +1,13 @@
+{
+    "default-src": [
+        "'self'"
+    ],
+    "script-src": [
+        "'self'",
+        "https://rum.hlx.page/"
+    ],
+    "connect-src": [
+        "'self'",
+        "https://rum.hlx.page/"
+    ]
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -84,6 +84,7 @@ async function setCSP() {
   const meta = document.createElement('meta');
   meta.setAttribute('http-equiv', 'Content-Security-Policy');
   meta.setAttribute('content', policy);
+  document.addEventListener("securitypolicyviolation", (e) => sampleRUM("csperror", {source: `${e.documentURI}:${e.lineNumber}:${e.columnNumber}`, target: e.blockedURI }));
   document.head.appendChild(meta);
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -84,7 +84,7 @@ async function setCSP() {
   const meta = document.createElement('meta');
   meta.setAttribute('http-equiv', 'Content-Security-Policy');
   meta.setAttribute('content', policy);
-  document.addEventListener("securitypolicyviolation", (e) => sampleRUM("csperror", {source: `${e.documentURI}:${e.lineNumber}:${e.columnNumber}`, target: e.blockedURI }));
+  document.addEventListener('securitypolicyviolation', (e) => sampleRUM('csperror', { source: `${e.documentURI}:${e.lineNumber}:${e.columnNumber}`, target: e.blockedURI }));
   document.head.appendChild(meta);
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -73,10 +73,27 @@ async function loadEager(doc) {
 }
 
 /**
+ * sets the Content-Security-Policy meta tag to the document based on JSON file
+ */
+
+async function setCSP() {
+  const resp = await fetch(`${window.hlx.codeBasePath}/scripts/csp.json`);
+  const json = await resp.json();
+  const directives = Object.keys(json);
+  const policy = directives.map((directive) => `${directive} ${json[directive].join(' ')}`).join('; ');
+  const meta = document.createElement('meta');
+  meta.setAttribute('http-equiv', 'Content-Security-Policy');
+  meta.setAttribute('content', policy);
+  document.head.appendChild(meta);
+}
+
+/**
  * Loads everything that doesn't need to be delayed.
  * @param {Element} doc The container element
  */
 async function loadLazy(doc) {
+  await setCSP();
+
   const main = doc.querySelector('main');
   await loadBlocks(main);
 


### PR DESCRIPTION
setting a `CSP` that is only transported over the wire once and then cached on the client.
manages the `CSP` in an easy to read JSON file

https://main--helix-project-boilerplate--adobe.hlx.live/
vs.
https://meta-csp--helix-project-boilerplate--adobe.hlx.live/?rum=1
