### PR TITLE
fix: revert to simple icons decoration and extract the spriting logic

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -185,9 +185,9 @@ export async function decorateIcons(element) {
           return;
         }
         // Styled icons don't play nice with the sprite approach because of shadow dom isolation
-        // and same for internal references
+        // how colors are defined, and internal references handled
         const svg = await response.text();
-        if (svg.match(/(<style | class=|url\(#| xlink:href="#)/)) {
+        if (svg.match(/(<style | (class|fill|stroke)=|url\(#| xlink:href="#)/) && !svg.match(/"currentcolor"/i)) {
           ICONS_CACHE[iconName] = {
             styled: true,
             html: svg
@@ -226,7 +226,9 @@ export async function decorateIcons(element) {
     const parent = span.firstElementChild?.tagName === 'A' ? span.firstElementChild : span;
     // Styled icons need to be inlined as-is, while unstyled ones can leverage the sprite
     if (ICONS_CACHE[iconName].styled) {
-      parent.innerHTML = ICONS_CACHE[iconName].html;
+      const img = document.createElement('img');
+      img.src = `${window.hlx.codeBasePath}/icons/${iconName}.svg`
+      parent.append(img);
     } else {
       parent.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg"><use href="#icons-sprite-${iconName}"/></svg>`;
     }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -189,12 +189,7 @@ export async function decorateIcons(element) {
         const svg = await response.text();
         if (svg.match(/(<style | (class|fill|stroke)=|url\(#| xlink:href="#)/) && !svg.match(/"currentcolor"/i)) {
           ICONS_CACHE[iconName] = {
-            styled: true,
-            html: svg
-              // rescope ids and references to avoid clashes across icons;
-              .replaceAll(/ id="([^"]+)"/g, (_, id) => ` id="${iconName}-${id}"`)
-              .replaceAll(/="url\(#([^)]+)\)"/g, (_, id) => `="url(#${iconName}-${id})"`)
-              .replaceAll(/ xlink:href="#([^"]+)"/g, (_, id) => ` xlink:href="#${iconName}-${id}"`),
+            html: null,
           };
         } else {
           ICONS_CACHE[iconName] = {
@@ -216,7 +211,7 @@ export async function decorateIcons(element) {
   const symbols = Object
     .keys(ICONS_CACHE).filter((k) => !svgSprite.querySelector(`#icons-sprite-${k}`))
     .map((k) => ICONS_CACHE[k])
-    .filter((v) => !v.styled)
+    .filter((v) => !!v.html)
     .map((v) => v.html)
     .join('\n');
   svgSprite.innerHTML += symbols;
@@ -225,7 +220,7 @@ export async function decorateIcons(element) {
     const iconName = Array.from(span.classList).find((c) => c.startsWith('icon-')).substring(5);
     const parent = span.firstElementChild?.tagName === 'A' ? span.firstElementChild : span;
     // Styled icons need to be inlined as-is, while unstyled ones can leverage the sprite
-    if (ICONS_CACHE[iconName].styled) {
+    if (!ICONS_CACHE[iconName].html) {
       const img = document.createElement('img');
       img.src = `${window.hlx.codeBasePath}/icons/${iconName}.svg`;
       parent.append(img);

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -158,12 +158,11 @@ export function toCamelCase(name) {
 }
 
 /**
- * Replace icons with inline SVG and prefix with codeBasePath.
  * Add <img> for icon, prefixed with codeBasePath and optional prefix.
  * @param {span} [element] span element with icon classes
  * @param {string} [prefix] prefix to be added to icon the src
  */
-export async function decorateIcons(span, prefix = '') {
+export function decorateIcon(span, prefix = '') {
   const iconName = Array.from(span.classList).find((c) => c.startsWith('icon-')).substring(5);
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
@@ -171,6 +170,18 @@ export async function decorateIcons(span, prefix = '') {
   img.loading = 'lazy';
 
   span.append(img);
+}
+
+/**
+ * Add <img> for icons, prefixed with codeBasePath and optional prefix.
+ * @param {Element} [element] Element containing icons
+ * @param {string} [prefix] prefix to be added to icon the src
+ */
+export function decorateIcons(element, prefix = '') {
+  const icons = [...element.querySelectorAll('span.icon')];
+  icons.forEach((span) => {
+    decorateIcon(span, prefix);
+  });
 }
 
 /**

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -227,7 +227,7 @@ export async function decorateIcons(element) {
     // Styled icons need to be inlined as-is, while unstyled ones can leverage the sprite
     if (ICONS_CACHE[iconName].styled) {
       const img = document.createElement('img');
-      img.src = `${window.hlx.codeBasePath}/icons/${iconName}.svg`
+      img.src = `${window.hlx.codeBasePath}/icons/${iconName}.svg`;
       parent.append(img);
     } else {
       parent.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg"><use href="#icons-sprite-${iconName}"/></svg>`;

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -184,20 +184,20 @@ export async function decorateIcons(element) {
           ICONS_CACHE[iconName] = false;
           return;
         }
-        // Styled icons don't play nice with the sprite approach because of shadow dom isolation
-        // how colors are defined, and internal references handled
         const svg = await response.text();
-        if (svg.match(/(<style | (class|fill|stroke)=|url\(#| xlink:href="#)/) && !svg.match(/"currentcolor"/i)) {
-          ICONS_CACHE[iconName] = {
-            html: null,
-          };
-        } else {
+        // Icons using the "currentcolor" value are meant to inherit from the current
+        // page context and should be inlined
+        if (svg.match(/"currentcolor"/i)) {
           ICONS_CACHE[iconName] = {
             html: svg
               .replace('<svg', `<symbol id="icons-sprite-${iconName}"`)
               .replace(/ width=".*?"/, '')
               .replace(/ height=".*?"/, '')
               .replace('</svg>', '</symbol>'),
+          };
+        } else { // Other icons are just plain images
+          ICONS_CACHE[iconName] = {
+            html: null,
           };
         }
       } catch (error) {


### PR DESCRIPTION
Most customers directly use svg icons as they were explored by their preferred application (Illustrator, etc.), and that markup isn't compatible with the spriting logic in most cases. On top of that, the current spriting implementation has required frequent patching and isn't likely that stable yet. As such, we want to revert to basic icons decoration by default, and move the spriting to the block party instead until it is considered mature enough.

Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.page/
- After: https://improve-icons--helix-project-boilerplate--adobe.hlx.page/
