### PR TITLE
fix: icons no more svgs

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -223,7 +223,7 @@ main img {
   width: 24px;
 }
 
-.icon svg {
+.icon img {
   height: 100%;
   width: 100%;
 }


### PR DESCRIPTION
Following up the icon refactoring (https://github.com/adobe/aem-lib/pull/15), no svg is used. I have checked the code and I could not find any other impact but maybe @davidnuescheler @fkakatie @ramboz you see something else.

Test URLs:
- Before: https://main--aem-boilerplate--adobe.hlx.page/
- After: https://icon-styles--aem-boilerplate--adobe.hlx.page/
