### PR TITLE
PSI should ideally run against .live and not .page

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--{repo}--{owner}.hlx.page/
-- After: https://<branch>--{repo}--{owner}.hlx.page/
+- Before: https://main--{repo}--{owner}.hlx.live/
+- After: https://<branch>--{repo}--{owner}.hlx.live/


### PR DESCRIPTION
Fix #269 

No Test URLs because this is just changing the PR template only and not any functionality.