### PR TITLE
chore: Update .renovaterc.json

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["github>adobe/helix-shared"]
+  "extends": ["config:recommended"]
 }


### PR DESCRIPTION
we should not extend from the helix-shared renovate configuration as it is tailored for helix dev and also include npm tokens for the private packages for `@adobe`. those don't seem to work on non adobe orgs.

