### PR TITLE
Add alt text support to decorateIcon

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -399,7 +399,8 @@ function decorateButtons(element) {
  * @param {string} [prefix] prefix to be added to icon the src
  */
 async function decorateIcon(span, prefix = '') {
-  const langPrefix = document.documentElement.lang === 'en' ? '' : document.documentElement.lang
+  const langPrefix = document.documentElement.lang === 'en' ? '' : document.documentElement.lang;
+  // eslint-disable-next-line no-use-before-define
   const placeholders = await fetchPlaceholders(langPrefix);
   const iconName = Array.from(span.classList)
     .find((c) => c.startsWith('icon-'))
@@ -408,7 +409,7 @@ async function decorateIcon(span, prefix = '') {
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
-  img.alt =  placeholders[toCamelCase(`icon-${iconName}`)] || iconName;
+  img.alt = placeholders[toCamelCase(`icon-${iconName}`)] || iconName;
   img.loading = 'lazy';
   span.append(img);
 }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -395,16 +395,20 @@ function decorateButtons(element) {
 
 /**
  * Add <img> for icon, prefixed with codeBasePath and optional prefix.
- * @param {span} [element] span element with icon classes
+ * @param {Element} [span] span element with icon classes
  * @param {string} [prefix] prefix to be added to icon the src
  */
-function decorateIcon(span, prefix = '') {
+async function decorateIcon(span, prefix = '') {
+  const langPrefix = document.documentElement.lang === 'en' ? '' : document.documentElement.lang
+  const placeholders = await fetchPlaceholders(langPrefix);
   const iconName = Array.from(span.classList)
     .find((c) => c.startsWith('icon-'))
     .substring(5);
+
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
+  img.alt =  placeholders[toCamelCase(`icon-${iconName}`)] || iconName;
   img.loading = 'lazy';
   span.append(img);
 }
@@ -414,11 +418,11 @@ function decorateIcon(span, prefix = '') {
  * @param {Element} [element] Element containing icons
  * @param {string} [prefix] prefix to be added to icon the src
  */
-function decorateIcons(element, prefix = '') {
+async function decorateIcons(element, prefix = '') {
   const icons = [...element.querySelectorAll('span.icon')];
-  icons.forEach((span) => {
-    decorateIcon(span, prefix);
-  });
+  await Promise.all(icons.map(async (span) => {
+    await decorateIcon(span, prefix);
+  }));
 }
 
 /**

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -398,7 +398,7 @@ function decorateButtons(element) {
  * @param {Element} [span] span element with icon classes
  * @param {string} [prefix] prefix to be added to icon the src
  */
-function decorateIcon(span, prefix = '') {
+function decorateIcon(span, prefix = '', alt = '') {
   const iconName = Array.from(span.classList)
     .find((c) => c.startsWith('icon-'))
     .substring(5);

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -398,10 +398,7 @@ function decorateButtons(element) {
  * @param {Element} [span] span element with icon classes
  * @param {string} [prefix] prefix to be added to icon the src
  */
-async function decorateIcon(span, prefix = '') {
-  const langPrefix = document.documentElement.lang === 'en' ? '' : document.documentElement.lang;
-  // eslint-disable-next-line no-use-before-define
-  const placeholders = await fetchPlaceholders(langPrefix);
+function decorateIcon(span, prefix = '') {
   const iconName = Array.from(span.classList)
     .find((c) => c.startsWith('icon-'))
     .substring(5);
@@ -409,7 +406,7 @@ async function decorateIcon(span, prefix = '') {
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
-  img.alt = placeholders[toCamelCase(`icon-${iconName}`)] || iconName;
+  img.alt = iconName;
   img.loading = 'lazy';
   span.append(img);
 }
@@ -419,11 +416,11 @@ async function decorateIcon(span, prefix = '') {
  * @param {Element} [element] Element containing icons
  * @param {string} [prefix] prefix to be added to icon the src
  */
-async function decorateIcons(element, prefix = '') {
+function decorateIcons(element, prefix = '') {
   const icons = [...element.querySelectorAll('span.icon')];
-  await Promise.all(icons.map(async (span) => {
-    await decorateIcon(span, prefix);
-  }));
+  icons.forEach((span) => {
+    decorateIcon(span, prefix);
+  });
 }
 
 /**

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -406,7 +406,12 @@ function decorateIcon(span, prefix = '') {
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
-  img.alt = iconName;
+  if (alt && alt.trim()) {
+    img.alt = alt;
+  } else {
+    img.alt = ' ';
+    img.setAttribute('role', 'presentation');
+  }
   img.loading = 'lazy';
   span.append(img);
 }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -409,7 +409,6 @@ function decorateIcon(span, prefix = '', alt = '') {
   if (alt && alt.trim()) {
     img.alt = alt;
   } else {
-    img.alt = ' ';
     img.setAttribute('role', 'presentation');
   }
   img.loading = 'lazy';

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -689,6 +689,7 @@ export {
   decorateBlock,
   decorateBlocks,
   decorateButtons,
+  decorateIcon,
   decorateIcons,
   decorateSections,
   decorateTemplateAndTheme,


### PR DESCRIPTION
Default the Alt Text to the iconName as referenced in markdown. 

Also support i18n lookup based on `icon-<icon-name>` key.

Fix #279 

Test URLs:
- After: https://feat-icon-alt-text--aem-eds-demo--bstopp.hlx.page/
