### PR TITLE
chore: update node version

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '16' #required for npm 8 or later.
+        node-version: '20'
     - run: npm install
     - run: npm run lint
       env:

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install dependencies
         run: npm ci
       - name: Run semantic-release


### PR DESCRIPTION
Updates node version to 20.x in the github actions for testing and releasing. this is required by the recent semantic-release 23.x update.

Test URLs:
- Before: https://main--aem-boilerplate--adobe.hlx.live/
- After: https://tripodsan-patch-2--aem-boilerplate--adobe.hlx.live/
