### PR TITLE
fix: link to cli in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ npm run lint
 
 1. Create a new repository based on the `aem-boilerplate` template and add a mountpoint in the `fstab.yaml`
 1. Add the [AEM Code Sync GitHub App](https://github.com/apps/aem-code-sync) to the repository
-1. Install the [AEM CLI](https://github.com/adobe/aem-cli): `npm install -g @adobe/aem-cli`
+1. Install the [AEM CLI](https://github.com/adobe/helix-cli): `npm install -g @adobe/aem-cli`
 1. Start AEM Proxy: `aem up` (opens your browser at `http://localhost:3000`)
 1. Open the `{repo}` directory in your favorite IDE and start coding :)


### PR DESCRIPTION
@cpilsworth Mentioned in discord that this link is broken. Since this is the starting point for a lot of customers I suggest we fix until the `helix-cli` repository is renamed to `aem-cli`.

wdyt?

URL for testing:

- https://readme-cli-link--aem-boilerplate--adobe.hlx.page/
