### PR TITLE
[Bug]  Cleanup workflow not working

### DIFF
--- a/.github/workflows/cleanup-on-create.yaml
+++ b/.github/workflows/cleanup-on-create.yaml
@@ -6,6 +6,7 @@ on:
   create:
     branches:
       - main
+  workflow_dispatch:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -13,7 +14,7 @@ jobs:
       contents: write
       actions: write
     # only run if commit message is "Initial commit" on main branch
-    if: ${{ github.ref == 'refs/heads/main' && ( !(contains(github.event, 'head_commit') || github.event.head_commit.message == 'Initial commit') ) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || ( github.ref == 'refs/heads/main' && !(contains(github.event, 'head_commit') || github.event.head_commit.message == 'Initial commit' )) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cleanup-on-create.yaml
+++ b/.github/workflows/cleanup-on-create.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       actions: write
     # only run if commit message is "Initial commit" on main branch
-    if: ${{ github.ref == 'refs/heads/main' && github.event.head_commit.message == 'Initial commit' }}
+    if: ${{  github.ref == 'refs/heads/main' &&  ( !(contains(github.event, 'head_commit') || github.event.head_commit.message == 'Initial commit') ) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
       - name: Commit changes
         run: |
           git config --local user.email "helix@adobe.com"
-          git config --local user.name "Helix Bot"
+          git config --local user.name "AEM Bot"
           git add .
           git commit -m "chore: cleanup repository template"
           git push

--- a/.github/workflows/cleanup-on-create.yaml
+++ b/.github/workflows/cleanup-on-create.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       actions: write
     # only run if commit message is "Initial commit" on main branch
-    if: ${{  github.ref == 'refs/heads/main' &&  ( !(contains(github.event, 'head_commit') || github.event.head_commit.message == 'Initial commit') ) }}
+    if: ${{ github.ref == 'refs/heads/main' && ( !(contains(github.event, 'head_commit') || github.event.head_commit.message == 'Initial commit') ) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Changes:

1. On Branch Creation Github event does not contain head_commit object. Added a conditional statement for same
2. Sometime workflow event is not triggered on branch creation, so added 'workflow_dispatch:' so that it can be manually triggered. 


Fix [#343](https://github.com/adobe/aem-boilerplate/issues/343)

Test URLs:
- Before: https://main--aem-boilerplate--adobe.hlx.page/
- After: https://main--aem-boilerplate--gargadobe.hlx.page/
