### PR TITLE
fix: header/footer fragment loading (#13)

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -10,7 +10,7 @@ export default async function decorate(block) {
   block.textContent = '';
 
   // load footer fragment
-  const footerPath = footerMeta.footer || '/footer';
+  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/footer';
   const fragment = await loadFragment(footerPath);
 
   // decorate footer DOM

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -93,7 +93,7 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
 export default async function decorate(block) {
   // load nav as fragment
   const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta).pathname : '/nav';
+  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
   const fragment = await loadFragment(navPath);
 
   // decorate nav DOM


### PR DESCRIPTION
This PR fixes the broken footer loading from a given `footer` field in the page metadata. 

It also addresses the use case where the `footer` or `nav` are configured as paths only instead of a link, for example when using bulk metadata it seems reasonable to configure `footer` and `nav` like

| Path | Nav | Footer |
| ----- | --- | ---- |
| /** | /nav | /footer |
| /de** | /de/nav | /de/footer |

- Before: https://main--aem-boilerplate--adobe.hlx.live/ 
- After: https://fix-header-footer-loading--aem-boilerplate--buuhuu.hlx.live/
