### PR TITLE
chore: unify header/footer decoration

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -6,14 +6,13 @@ import { loadFragment } from '../fragment/fragment.js';
  * @param {Element} block The footer block element
  */
 export default async function decorate(block) {
+  // load footer as fragment
   const footerMeta = getMetadata('footer');
-  block.textContent = '';
-
-  // load footer fragment
-  const footerPath = footerMeta.footer || '/footer';
+  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/footer';
   const fragment = await loadFragment(footerPath);
 
   // decorate footer DOM
+  block.textContent = '';
   const footer = document.createElement('div');
   while (fragment.firstElementChild) footer.append(fragment.firstElementChild);
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -87,16 +87,17 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
 }
 
 /**
- * decorates the header, mainly the nav
+ * loads and decorates the header, mainly the nav
  * @param {Element} block The header block element
  */
 export default async function decorate(block) {
   // load nav as fragment
   const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta).pathname : '/nav';
+  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
   const fragment = await loadFragment(navPath);
 
   // decorate nav DOM
+  block.textContent = '';
   const nav = document.createElement('nav');
   nav.id = 'nav';
   while (fragment.firstElementChild) nav.append(fragment.firstElementChild);


### PR DESCRIPTION
unify decoration sequence for header and footer (same comments, same order)

fixes bug with header that previously left artifact of a stray empty div 

Test URLs:
- Before: https://main--aem-boilerplate--adobe.hlx.live/
- After: https://unify-head-foot--aem-boilerplate--adobe.hlx.live/
