### PR TITLE
fix: cards fail if the text contains an icon

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -12,7 +12,7 @@ export default function decorate(block) {
     });
     ul.append(li);
   });
-  ul.querySelectorAll('img').forEach((img) => img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
+  ul.querySelectorAll('picture > img').forEach((img) => img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
   block.textContent = '';
   block.append(ul);
 }


### PR DESCRIPTION
Since icons `:icon-name:` are rendered as `<span class="icon icon-icon-name"></span>` and decorated with `<span class="icon icon-icon-name"><img ...></span>` now, querying all `<img>` in the list of cards and assuming they all have a closest `<picture>` is wrong. It will fail for the icon `<img>` and the cards block will be broken.

With this change I limit the selector to `<img>` that actually have a `<picture>` parent. 

Test URLs:
- Before: https://main--aem-boilerplate--adobe.hlx.live/
- After: https://fix-cards-text-with-icon--aem-boilerplate--buuhuu.hlx.live/
