### PR TITLE
Bug fix: fragment block should include fragment classnames [HTML DOM …

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -46,10 +46,13 @@ export default async function decorate(block) {
   const path = link ? link.getAttribute('href') : block.textContent.trim();
   const fragment = await loadFragment(path);
   if (fragment) {
-    const fragmentSection = fragment.querySelector(':scope .section');
-    if (fragmentSection) {
-      block.closest('.section').classList.add(...fragmentSection.classList);
-      block.closest('.fragment').replaceWith(...fragment.childNodes);
+    const fragmentSections = fragment.querySelectorAll(':scope .section');
+    if (fragmentSections && fragmentSections.length > 0) {
+      const blockDiv = block.closest('.fragment');
+      blockDiv.innerHTML = '';
+      fragmentSections.forEach((section) => {
+        blockDiv.appendChild(section);
+      });
     }
   }
 }

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,0 @@
-mountpoints:
-  /: https://drive.google.com/drive/u/0/folders/1MGzOt7ubUh3gu7zhZIPb7R7dyRzG371j


### PR DESCRIPTION
…change]

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #409 

Test URLs:
- Before: https://main--com--ancestry.aem.live/en/
- After: https://fragment-block-fix--com--ancestry.aem.live/en/
