### PR TITLE
feat: remove unnecessary sampleRUM.enhance

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,7 +11,6 @@ import {
   loadSection,
   loadSections,
   loadCSS,
-  sampleRUM,
 } from './aem.js';
 
 /**
@@ -81,8 +80,6 @@ async function loadEager(doc) {
     document.body.classList.add('appear');
     await loadSection(main.querySelector('.section'), waitForFirstImage);
   }
-
-  sampleRUM.enhance();
 
   try {
     /* if desktop (proxy for fast connection) or fonts already loaded, load fonts.css */


### PR DESCRIPTION
Consequence of https://github.com/adobe/aem-lib/pull/105 - sampleRUM.enhance is not necessary.
In case project already has it, https://github.com/adobe/helix-rum-js/pull/220 ensure enhance is only performing once.

Test URLs:
- Before: https://main--aem-boilerplate--adobe.aem.live/
- After: https://no-enhance--aem-boilerplate--adobe.aem.live/
