### PR TITLE
Bug fix: fragment block should include fragment classnames [HTML DOM change]

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -46,10 +46,10 @@ export default async function decorate(block) {
   const path = link ? link.getAttribute('href') : block.textContent.trim();
   const fragment = await loadFragment(path);
   if (fragment) {
-    const fragmentSection = fragment.querySelector(':scope .section');
-    if (fragmentSection) {
-      block.closest('.section').classList.add(...fragmentSection.classList);
-      block.closest('.fragment').replaceWith(...fragment.childNodes);
+    const blockDiv = block.closest('.fragment');
+    if (blockDiv) {
+      blockDiv.innerHTML = '';
+      blockDiv.append(...fragment.childNodes);
     }
   }
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](https://github.com/adobe/aem-boilerplate/issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/adobe/aem-boilerplate/issues/409

Test URLs:

Before: https://fragment-block-fix--ancestry--aemsites.aem.live/drafts/ujjgupta/test-frgament
After: https://main--ancestry--aemsites.aem.live/drafts/ujjgupta/test-frgament
