### PR TITLE
change collectbase to /.rum/

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -70,7 +70,7 @@ function sampleRUM(checkpoint, data) {
         });
 
         sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE || '/', new URL('https://rum.hlx.page'));
-        sampleRUM.collectBaseURL = sampleRUM.collectBaseURL || sampleRUM.baseURL;
+        sampleRUM.collectBaseURL = sampleRUM.collectBaseURL || new URL(window.origin);
         sampleRUM.sendPing = (ck, time, pingData = {}) => {
           // eslint-disable-next-line max-len, object-curly-newline
           const rumData = JSON.stringify({


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

This change merely adjusts the collectBaseURL to use the window.origin and thus not the rum.hlx.page domain.

- https://main--aem-boilerplate--adobe.aem.live/
- https://rummy--aem-boilerplate--adobe.aem.live/
