### PR TITLE
chore: disable renovate by default

### DIFF
--- a/.github/workflows/cleanup-on-create.yaml
+++ b/.github/workflows/cleanup-on-create.yaml
@@ -26,6 +26,7 @@ jobs:
         run: | 
           rm -rf \
             .github/workflows/cleanup-on-create.yaml \
+            .renovaterc.json \
             CHANGELOG.md
 
       - name: Initialize README


### PR DESCRIPTION
If you create a new project based on the boilerplate and if renovate is enabled for all projects on the customer org, renovate will automatically be enabled and might lead to incoming PR the dev team does not necessarily understand. Once they fully own the code, they might need to set it up for their own needs.
Also, if the customer is using something else, the config file pollutes the repo.
