### PR TITLE
chore: trial - ignore psi check for renovate dev dependencies update

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,3 +1,8 @@
 {
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "packageRules": [{
+      "matchDepTypes": ["devDependencies"],
+      "labels": ["ignore-psi-check"], 
+      "automerge": true
+  }]
 }


### PR DESCRIPTION
Should make the renovate dev dependencies management a bit smoother: auto merge if linting is successful. 
