### PR TITLE
Enhance `fetchPlaceholders` function to support overrides and dot notation labels

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -506,27 +506,47 @@ function decorateSections(main) {
  */
 // eslint-disable-next-line import/prefer-default-export
 async function fetchPlaceholders(prefix = 'default') {
+  const overrides = getMetadata('placeholders') || getMetadata('root')?.replace(/\/$/, '/placeholders.json') || '';
+  const [fallback, override] = overrides.split('\n');
   window.placeholders = window.placeholders || {};
+
   if (!window.placeholders[prefix]) {
     window.placeholders[prefix] = new Promise((resolve) => {
-      fetch(`${prefix === 'default' ? '' : prefix}/placeholders.json`)
-        .then((resp) => {
+      const url = fallback || `${prefix === 'default' ? '' : prefix}/placeholders.json`;
+      Promise.all([fetch(url), override ? fetch(override) : Promise.resolve()])
+        .then(async ([resp, oResp]) => {
           if (resp.ok) {
-            return resp.json();
+            if (oResp?.ok) {
+              return Promise.all([resp.json(), await oResp.json()]);
+            }
+            return Promise.all([resp.json(), {}]);
           }
           return {};
         })
-        .then((json) => {
+
+        .then(([json, oJson]) => {
           const placeholders = {};
-          json.data
-            .filter((placeholder) => placeholder.Key)
-            .forEach((placeholder) => {
-              placeholders[toCamelCase(placeholder.Key)] = placeholder.Text;
-            });
+          const overrideMap = new Map(
+            oJson?.data?.map(({ Key, Value }) => [Key, Value]) || [],
+          );
+
+          json.data.forEach(({ Key, Value: originalValue }) => {
+            if (!Key) return;
+            const finalValue = overrideMap.has(Key) ? overrideMap.get(Key) : originalValue;
+            const keys = Key.split('.');
+            const lastKey = keys.pop();
+            const target = keys.reduce((obj, key) => {
+              obj[key] = obj[key] || {};
+              return obj[key];
+            }, placeholders);
+            target[lastKey] = finalValue;
+          });
           window.placeholders[prefix] = placeholders;
-          resolve(window.placeholders[prefix]);
+          resolve(placeholders);
         })
-        .catch(() => {
+        .catch((error) => {
+          // eslint-disable-next-line no-console
+          console.error('error loading placeholders', error);
           // error loading placeholders
           window.placeholders[prefix] = {};
           resolve(window.placeholders[prefix]);
@@ -535,7 +555,6 @@ async function fetchPlaceholders(prefix = 'default') {
   }
   return window.placeholders[`${prefix}`];
 }
-
 /**
  * Builds a block DOM Element from a two dimensional array, string, or object
  * @param {string} blockName name of the block


### PR DESCRIPTION
# Enhance Placeholders Functionality

This update extends the `fetchPlaceholders` function in `aem.js` to support more flexible, structured, and maintainable placeholder definitions. These improvements directly support use cases such as multistore localization, A/B testing, and streamlined integration with Commerce Drop-ins.

---

## Use Cases

### Multistore Localization
 This implementation is already used in the [Commerce Boilerplate](https://experienceleague.adobe.com/developer/commerce/storefront/merchants/get-started/multistore/) to load placeholders from locale-specific root folders, simplifying support for multilingual and multi-site setups.

**Bulk Metadata — placeholders.xlsx**
<img width="850" alt="Screenshot 2025-04-07 at 11 48 04 AM" src="https://github.com/user-attachments/assets/0a29599b-5074-4939-bb33-28d7c79ac2f8" />

### A/B Experimentation

Overrides let teams tailor placeholders for different variations—like in [Commerce A/B experiments](https://experienceleague.adobe.com/developer/commerce/storefront/merchants/get-started/experiments/)—without requiring authors to manage large, complex variant spreadsheets.

![image](https://github.com/user-attachments/assets/a78c6bb6-01e9-4762-a278-ae0329ddd20c)


### Commerce Drop-ins Integration

Dot notation support enables one-to-one mapping between placeholder keys and their usage in Commerce Drop-ins, reducing the need for custom transformation logic. 

**placeholders.xlsx**
<img width="1271" alt="image" src="https://github.com/user-attachments/assets/4b13da0c-6ba0-4366-8e63-3d1473492603" />

**Implementation Example**

  ```js
// use a placeholder in a Block
const labels = await fetchPlaceholders();
// existing
elem.innerText = labels['my-flat-label'];
// but also (new)
elem.innerText = labels.foo.bar;

// apply placeholders to drop-in
await initializeDropin(async () => {
  setFetchGraphQlHeaders(await getHeaders('cart'));

  const labels = await fetchPlaceholders();
  const langDefinitions = {
    default: {
      ...labels,
    },
  };

  return initializers.mountImmediately(initialize, { langDefinitions });
})();
```

---

Test URLs:

Before: https://main--aem-boilerplate--adobe.aem.live/
After: https://placeholders2--aem-boilerplate--fnhipster.aem.live/
