### PR TITLE
chore: refactor for more compatible media queries

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["stylelint-config-standard"]
+  "extends": ["stylelint-config-standard"],
+  "rules": {
+    "media-feature-range-notation": "prefix"
+  }
 }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -19,7 +19,7 @@
   display: block;
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   .columns > div {
     align-items: center;
     flex-direction: unset;

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -13,7 +13,7 @@ footer .footer p {
   margin: 0;
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   footer .footer > div {
     padding: 40px 32px 24px;
   }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -30,7 +30,7 @@ header nav[aria-expanded='true'] {
   min-height: 100dvh;
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   header nav {
     display: flex;
     justify-content: space-between;
@@ -128,7 +128,7 @@ header nav[aria-expanded='true'] .nav-hamburger-icon::after {
   transform: rotate(-45deg);
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   header nav .nav-hamburger {
     display: none;
     visibility: hidden;
@@ -181,7 +181,7 @@ header nav .nav-sections ul > li > ul > li {
   font-weight: 400;
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   header nav .nav-sections {
     display: block;
     visibility: visible;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -30,7 +30,7 @@
   height: 100%;
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   .hero {
     padding: 40px 32px;
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -53,7 +53,7 @@
   src: local('Arial');
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   :root {
     /* body sizes */
     --body-font-size-m: 18px;
@@ -242,7 +242,7 @@ main > .section:first-of-type {
   margin-top: 0;
 }
 
-@media (width >= 900px) {
+@media (min-width: 900px) {
   main > .section > div {
     padding: 0 32px;
   }


### PR DESCRIPTION
https://no-range-mq--aem-boilerplate--adobe.aem.live/

there is a bit of a conflict with our guidance to not change the default linter configs https://www.aem.live/docs/dev-collab-and-good-practices#linting and the default stylelint config to use media query range syntax. the range syntax is relatively new and has only 92% support https://caniuse.com/css-media-range-syntax

the failure for browsers that don't support it, in our "mobile first" setup really means that only affects desktop (ish) browsers, and they would usually just see the mobile styling.
in cases where js is used via media queries or viewport width dimensions there could be further issues. 

i am not entirely sure what's the right thing to do here, so i am just raising the PR so we have a place to see the impact and debate. 