### PR TITLE
chore: remove fstab

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,0 @@
-mountpoints:
-  /: https://drive.google.com/drive/u/0/folders/1MGzOt7ubUh3gu7zhZIPb7R7dyRzG371j


### PR DESCRIPTION
Removing fstab to trigger new installation.

https://remove-fstab--aem-boilerplate--adobe.aem.live/

This will send the user to this success page instead.

<img width="813" height="773" alt="image" src="https://github.com/user-attachments/assets/5f5ea5f5-f36f-4a7b-a6f9-5f31a0247d10" />
