### PR TITLE
feat: use new OpTel domain

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -70,7 +70,7 @@ function sampleRUM(checkpoint, data) {
           sampleRUM('error', errData);
         });
 
-        sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE || '/', new URL('https://rum.hlx.page'));
+        sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE || '/', new URL('https://ot.aem.live'));
         sampleRUM.collectBaseURL = sampleRUM.collectBaseURL || sampleRUM.baseURL;
         sampleRUM.sendPing = (ck, time, pingData = {}) => {
           // eslint-disable-next-line max-len, object-curly-newline


### PR DESCRIPTION
Update the default OpTel domain from rum.hlx.page to ot.aem.live

BEFORE: https://main--aem-boilerplate--adobe.aem.page/?rum=on
AFTER: https://new-optel-domain--aem-boilerplate--adobe.aem.page/?rum=on

OpTel Explorer loads with a domain key at https://www.aem.live/tools/rum/explorer.html?domain=new-optel-domain--aem-boilerplate--adobe.aem.page&view=month&domainkey=incognito which confirms data was collected.