### PR TITLE
feat: add csp data collection

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -70,6 +70,16 @@ function sampleRUM(checkpoint, data) {
           sampleRUM('error', errData);
         });
 
+        window.addEventListener('securitypolicyviolation', (e) => {
+          if (e.blockedURI.includes('helix-rum-enhancer')) {
+            const errData = {
+              source: 'csp',
+              target: e.blockedURI,
+            };
+            sampleRUM.sendPing('error', timeShift(), errData);
+          }
+        });
+
         sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE || '/', new URL('https://ot.aem.live'));
         sampleRUM.collectBaseURL = sampleRUM.collectBaseURL || sampleRUM.baseURL;
         sampleRUM.sendPing = (ck, time, pingData = {}) => {


### PR DESCRIPTION
Add collection for situations when the helix-rum-enhancer fails to load due to content-security-policy.  This will help identify customers in need of implementation fix.

Test URLs:
- Before: https://main--aem-boilerplate--adobe.aem.page/?rum=on ---> collection is fine
- After CSP good: https://csp--aem-boilerplate--adobe.aem.page/?rum=on ---> collection is still fine, no regression
- After CSP bad: https://csp-error--aem-boilerplate--adobe.aem.page/?rum=on ---> only top and error (with source csp) are collected

The csp-error branch will never get merged.  The [commit](https://github.com/adobe/aem-boilerplate/commit/b764bda33e3e57c17c1eeb0cf342ce284b85d7a0) in that branch simply breaks the CSP for test purposes.

Once merged, these changes will apply only to the boilerplate.  A similar change will need to be made to the helix-rum-js repository.
