### PR TITLE
fix: prevent duplicate hero element creation when block is used

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -22,6 +22,10 @@ function buildHeroBlock(main) {
   const picture = main.querySelector('picture');
   // eslint-disable-next-line no-bitwise
   if (h1 && picture && (h1.compareDocumentPosition(picture) & Node.DOCUMENT_POSITION_PRECEDING)) {
+    // Check if h1 or picture is already inside a hero block
+    if (h1.closest('.hero') || picture.closest('.hero')) {
+      return; // Don't create a duplicate hero block
+    }
     const section = document.createElement('div');
     section.append(buildBlock('hero', { elems: [picture, h1] }));
     main.prepend(section);


### PR DESCRIPTION
### [Related/downstream change](https://github.com/hlxsites/aem-boilerplate-commerce/pull/979)
----
The boilerplate assumes that if an image and h1 are on the page, we should "auto-block" the hero block. But we _also_ have a literal `hero` block, so auto-blocking is not necessary. We should gracefully handle both cases.

This change introduces a fix which ensures that if the block instrumentation exists in the page source, it will NOT auto-block.

In this PR, both manners of implementing a hero should work - using the block or just using an image + h1.

With block
<img width="1014" height="910" alt="image" src="https://github.com/user-attachments/assets/35882663-3eb4-4051-9622-8e2b261fb521" />
Without block
<img width="994" height="874" alt="image" src="https://github.com/user-attachments/assets/8b673fff-7283-4588-9a89-7d557b3f527d" />

Test URLs:
- Before with hero block: https://main--aem-boilerplate-commerce--hlxsites.aem.live/drafts/rugh/double-hero-debug
- Fix with hero block: https://dupe-hero-fix--aem-boilerplate-commerce--hlxsites.aem.live/drafts/rugh/double-hero-debug
- Before with just image/h1: https://main--aem-boilerplate-commerce--hlxsites.aem.live/drafts/rugh/double-hero-debug-2
- Fix with just image/h1: https://dupe-hero-fix--aem-boilerplate-commerce--hlxsites.aem.live/drafts/rugh/double-hero-debug-2
