### PR TITLE
Fix/preserve fragment classes

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -47,10 +47,6 @@ export default async function decorate(block) {
   const path = link ? link.getAttribute('href') : block.textContent.trim();
   const fragment = await loadFragment(path);
   if (fragment) {
-    const fragmentSection = fragment.querySelector(':scope .section');
-    if (fragmentSection) {
-      block.closest('.section').classList.add(...fragmentSection.classList);
-      block.closest('.fragment').replaceWith(...fragment.childNodes);
-    }
+    block.replaceChildren(...fragment.childNodes);
   }
 }

--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -46,7 +46,5 @@ export default async function decorate(block) {
   const link = block.querySelector('a');
   const path = link ? link.getAttribute('href') : block.textContent.trim();
   const fragment = await loadFragment(path);
-  if (fragment) {
-    block.replaceChildren(...fragment.childNodes);
-  }
+  if (fragment) block.replaceChildren(...fragment.childNodes);
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -50,8 +50,8 @@ async function loadFonts() {
  */
 function buildAutoBlocks(main) {
   try {
-    // auto block `*/fragments/*` references
-    const fragments = main.querySelectorAll('a[href*="/fragments/"]');
+    // auto load `*/fragments/*` references
+    const fragments = [...main.querySelectorAll('a[href*="/fragments/"]')].filter((f) => !f.closest('.fragment'));
     if (fragments.length > 0) {
       // eslint-disable-next-line import/no-cycle
       import('../blocks/fragment/fragment.js').then(({ loadFragment }) => {
@@ -59,7 +59,7 @@ function buildAutoBlocks(main) {
           try {
             const { pathname } = new URL(fragment.href);
             const frag = await loadFragment(pathname);
-            fragment.parentElement.replaceWith(frag.firstElementChild);
+            fragment.parentElement.replaceWith(...frag.children);
           } catch (error) {
             // eslint-disable-next-line no-console
             console.error('Fragment loading failed', error);


### PR DESCRIPTION
fixes fragment rendering bugs in both auto-blocked and authored fragment blocks.

Fix #409 
Supersedes #434 

## Changes

1. **fragment blocks preserve authored classes** (`blocks/fragment/fragment.js`)
   - Uses `replaceChildren()` to keep block wrapper and classes intact

2. **auto-loaded fragments preserve all sections** (`scripts/scripts.js`)
   - Fixed bug where only first section rendered from multi-section fragments
   - Changed `frag.firstElementChild` → `...frag.children`

## Test URLs:

- Before: https://main--aem-boilerplate--adobe.aem.live/
- After: https://fix-preserve-fragment-classes--aem-boilerplate--adobe.aem.live/
- Before: https://main--vitamix--aemsites.aem.page/us/en_us/drafts/fkakatie/fragment-test
- After: https://fragment-test--vitamix--aemsites.aem.page/us/en_us/drafts/fkakatie/fragment-test
- Before: https://main--vitamix--aemsites.aem.network/vr/en_us/
- After: https://fragment-test--vitamix--aemsites.aem.network/vr/en_us/
