### PR TITLE
fix: prevent protocol-relative URLs in fragment loader (#577)

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -19,7 +19,7 @@ import {
  * @returns {HTMLElement} The root element of the fragment
  */
 export async function loadFragment(path) {
-  if (path && path.startsWith('/')) {
+  if (path && path.startsWith('/') && !path.startsWith('//')) {
     const resp = await fetch(`${path}.plain.html`);
     if (resp.ok) {
       const main = document.createElement('main');


### PR DESCRIPTION
Fix #577

URL for testing:
- https://main--aem-boilerplate--adobe.aem.live/