### PR TITLE
chore: add *.min.js to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 helix-importer-ui
+*.min.js


### PR DESCRIPTION
Fix #438

## Summary

Adds `*.min.js` to `.eslintignore` to prevent ESLint from linting minified JavaScript files.

## Why This Change

Downstream projects that include minified martech plugins or third-party libraries encounter CI failures when ESLint attempts to lint these files. Minified files inherently don't follow linting rules (long lines, missing semicolons, etc.) and will never pass standard checks.

This generic pattern provides a future-proof solution that benefits all adopters without requiring project-specific configuration.

## Test URLs:
- Before: https://main--aem-boilerplate--adobe.aem.live/
- After: https://ignore-min--aem-boilerplate--adobe.aem.live/
