### PR TITLE
feat: open file links in new tabs automatically

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -9,12 +9,13 @@ function decorateFileLinks(doc) {
     '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx',
     '.pdf', '.zip', '.mp4', '.mov', '.avi',
   ];
-  
+
   doc.querySelectorAll('a[href]').forEach((link) => {
     try {
       const url = new URL(link.href);
-      const hasFileExtension = fileExtensions.some((ext) => url.pathname.toLowerCase().endsWith(ext));
-      
+      const pathname = url.pathname.toLowerCase();
+      const hasFileExtension = fileExtensions.some((ext) => pathname.endsWith(ext));
+
       if (hasFileExtension && !link.hasAttribute('target')) {
         link.setAttribute('target', '_blank');
       }
@@ -24,4 +25,4 @@ function decorateFileLinks(doc) {
   });
 }
 
-decorateFileLinks(doc);
+decorateFileLinks(document);

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,1 +1,27 @@
 // add delayed functionality here
+
+/**
+ * Decorates links to file types to open in new tabs.
+ * @param {Element} doc The container element
+ */
+function decorateFileLinks(doc) {
+  const fileExtensions = [
+    '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx',
+    '.pdf', '.zip', '.mp4', '.mov', '.avi',
+  ];
+  
+  doc.querySelectorAll('a[href]').forEach((link) => {
+    try {
+      const url = new URL(link.href);
+      const hasFileExtension = fileExtensions.some((ext) => url.pathname.toLowerCase().endsWith(ext));
+      
+      if (hasFileExtension && !link.hasAttribute('target')) {
+        link.setAttribute('target', '_blank');
+      }
+    } catch (e) {
+      // Invalid URL, skip
+    }
+  });
+}
+
+decorateFileLinks(doc);


### PR DESCRIPTION
Automatically opens links to file types (PDF, DOC, media, etc.) in new tabs.

Runs in `loadDelayed` as a progressive enhancement (good example of the kind of thing that belongs there). Projects can easily extend or override with their own link decoration rules. No breaking changes.

Addresses #119

Test URLs:
- Before: https://main--aem-boilerplate--adobe.aem.live/
- After: https://file-target-blank--aem-boilerplate--adobe.aem.live/


