### PR TITLE
feat: button migration

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -2,7 +2,6 @@ import {
   buildBlock,
   loadHeader,
   loadFooter,
-  decorateButtons,
   decorateIcons,
   decorateSections,
   decorateBlocks,
@@ -76,17 +75,55 @@ function buildAutoBlocks(main) {
 }
 
 /**
+ * Decorates formatted links to style them as buttons.
+ * @param {HTMLElement} main The main container element
+ */
+function decorateButtons(main) {
+  main.querySelectorAll('p a[href]').forEach((a) => {
+    a.title = a.title || a.textContent;
+    const p = a.closest('p');
+    const text = a.textContent.trim();
+
+    // quick structural checks
+    if (a.querySelector('img') || p.textContent.trim() !== text) return;
+
+    // skip URL display links
+    try {
+      if (new URL(a.href).href === new URL(text, window.location).href) return;
+    } catch { /* continue */ }
+
+    // require authored formatting for buttonization
+    const strong = a.closest('strong');
+    const em = a.closest('em');
+    if (!strong && !em) return;
+
+    p.className = 'button-wrapper';
+    a.className = 'button';
+    if (strong && em) {
+      a.classList.add('accent');
+      const outer = strong.contains(em) ? strong : em;
+      outer.replaceWith(a);
+    } else if (strong) {
+      a.classList.add('primary');
+      strong.replaceWith(a);
+    } else {
+      a.classList.add('secondary');
+      em.replaceWith(a);
+    }
+  });
+}
+
+/**
  * Decorates the main element.
  * @param {Element} main The main element
  */
 // eslint-disable-next-line import/prefer-default-export
 export function decorateMain(main) {
-  // hopefully forward compatible button decoration
-  decorateButtons(main);
   decorateIcons(main);
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
+  decorateButtons(main);
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -99,7 +99,7 @@ function decorateButtons(main) {
 
     p.className = 'button-wrapper';
     a.className = 'button';
-    if (strong && em) {
+    if (strong && em) { // high-impact call-to-action
       a.classList.add('accent');
       const outer = strong.contains(em) ? strong : em;
       outer.replaceWith(a);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -192,14 +192,7 @@ button.button {
 }
 
 a.button[aria-disabled="true"],
-a.button[aria-disabled="true"]:hover,
-a.button[aria-disabled="true"]:focus-visible,
-button.button:disabled,
-button.button:disabled:hover,
-button.button:disabled:focus-visible {
-  background-color: var(--light-color) !important;
-  border-color: var(--light-color) !important;
-  color: var(--dark-color) !important;
+button.button:disabled {
   cursor: not-allowed;
   pointer-events: none;
 }
@@ -220,6 +213,17 @@ button.button.primary:focus-visible {
   color: var(--light-color);
 }
 
+a.button.primary[aria-disabled="true"],
+a.button.primary[aria-disabled="true"]:hover,
+a.button.primary[aria-disabled="true"]:focus-visible,
+button.button.primary:disabled,
+button.button.primary:disabled:hover,
+button.button.primary:disabled:focus-visible {
+  background-color: var(--light-color);
+  border-color: var(--light-color);
+  color: var(--dark-color);
+}
+
 a.button.secondary,
 button.button.secondary {
   border-color: var(--text-color);
@@ -233,6 +237,17 @@ button.button.secondary:hover,
 button.button.secondary:focus-visible {
   border-color: var(--dark-color);
   background-color: var(--light-color);
+  color: var(--dark-color);
+}
+
+a.button.secondary[aria-disabled="true"],
+a.button.secondary[aria-disabled="true"]:hover,
+a.button.secondary[aria-disabled="true"]:focus-visible,
+button.button.secondary:disabled,
+button.button.secondary:disabled:hover,
+button.button.secondary:disabled:focus-visible {
+  background-color: var(--light-color);
+  border-color: var(--light-color);
   color: var(--dark-color);
 }
 
@@ -250,6 +265,17 @@ button.button.accent:hover,
 button.button.accent:focus-visible {
   border-color: var(--link-hover-color);
   background-color: var(--link-hover-color);
+}
+
+a.button.accent[aria-disabled="true"],
+a.button.accent[aria-disabled="true"]:hover,
+a.button.accent[aria-disabled="true"]:focus-visible,
+button.button.accent:disabled,
+button.button.accent:disabled:hover,
+button.button.accent:disabled:focus-visible {
+  background-color: var(--light-color);
+  border-color: var(--light-color);
+  color: var(--dark-color);
 }
 
 main img {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -166,48 +166,90 @@ a:hover {
 }
 
 /* buttons */
-a.button:any-link,
-button {
-  box-sizing: border-box;
-  display: inline-block;
-  max-width: 100%;
+p.button-wrapper {
   margin: 12px 0;
+}
+
+a.button:any-link,
+button.button {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  margin: 0;
   border: 2px solid transparent;
   border-radius: 2.4em;
   padding: 0.5em 1.2em;
-  font-family: var(--body-font-family);
-  font-style: normal;
+  font: inherit;
   font-weight: 500;
   line-height: 1.25;
-  text-align: center;
   text-decoration: none;
-  background-color: var(--link-color);
-  color: var(--background-color);
   cursor: pointer;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-a.button:hover,
-a.button:focus,
-button:hover,
-button:focus {
-  background-color: var(--link-hover-color);
-  cursor: pointer;
+a.button[aria-disabled="true"],
+a.button[aria-disabled="true"]:hover,
+a.button[aria-disabled="true"]:focus-visible,
+button.button:disabled,
+button.button:disabled:hover,
+button.button:disabled:focus-visible {
+  background-color: var(--light-color) !important;
+  border-color: var(--light-color) !important;
+  color: var(--dark-color) !important;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
-button:disabled,
-button:disabled:hover {
-  background-color: var(--light-color);
-  cursor: unset;
+a.button.primary,
+button.button.primary {
+  border-color: var(--text-color);
+  background-color: var(--text-color);
+  color: var(--background-color);
+}
+
+a.button.primary:hover,
+a.button.primary:focus-visible,
+button.button.primary:hover,
+button.button.primary:focus-visible {
+  border-color: var(--dark-color);
+  background-color: var(--dark-color);
+  color: var(--light-color);
 }
 
 a.button.secondary,
-button.secondary {
-  background-color: unset;
-  border: 2px solid currentcolor;
+button.button.secondary {
+  border-color: var(--text-color);
+  background-color: transparent;
   color: var(--text-color);
+}
+
+a.button.secondary:hover,
+a.button.secondary:focus-visible,
+button.button.secondary:hover,
+button.button.secondary:focus-visible {
+  border-color: var(--dark-color);
+  background-color: var(--light-color);
+  color: var(--dark-color);
+}
+
+/* high-impact call-to-action */
+a.button.accent,
+button.button.accent {
+  border-color: var(--link-color);
+  background-color: var(--link-color);
+  color: var(--background-color);
+}
+
+a.button.accent:hover,
+a.button.accent:focus-visible,
+button.button.accent:hover,
+button.button.accent:focus-visible {
+  border-color: var(--link-hover-color);
+  background-color: var(--link-hover-color);
 }
 
 main img {


### PR DESCRIPTION
Migrate button decoration from [aem-lib](https://github.com/adobe/aem-lib) to boilerplate

Test URLs:
- Before: https://main--aem-boilerplate--adobe.aem.live/
- After: https://button-migration--aem-boilerplate--adobe.aem.live/

## Summary

Moves `decorateButtons` from aem-lib to boilerplate with improved opt-in behavior and visual hierarchy.

**Why:** Button decoration touches styles and should live in the editable boilerplate, not the protected aem-lib. Users should be empowered to customize button behavior without touching aem.js.

## Changes

**Decoration logic** (`scripts/scripts.js`):
- Opt-in only: plain links stay links
- **Bold** → primary button (dark solid)
- _Italic_ → secondary button (outlined)
- **_Bold+italic_** → accent button (blue solid, for CTAs)

**Styles** (`styles/styles.css`):
- Three button variants with clear hierarchy
- Modern `inline-flex` layout
- Proper disabled states (`aria-disabled` for links, `disabled` for buttons)
- `focus-visible` for keyboard navigation
- Semantic `button.button` selector (opt-in for developers too)

## Breaking Changes

**Incompatible.** Plain links in paragraphs no longer auto-convert to buttons. Authors must use bold or italic formatting to create buttons.

**Migration:** Add bold formatting to existing button links in content.

## Coordination

⚠️ Requires tandem [PR 199 in aem-lib](https://github.com/adobe/aem-lib/pull/199) to remove decorateButtons (v3.0.0 breaking change with [MIGRATION.md](https://github.com/adobe/aem-lib/blob/f0318933e9204e668026d6b629f7318373bfc4a2/MIGRATION.md)).