### PR TITLE
feat: use requestIdleCallback for delayed script loading

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -139,7 +139,14 @@ async function loadLazy(doc) {
  */
 function loadDelayed() {
   // eslint-disable-next-line import/no-cycle
-  window.setTimeout(() => import('./delayed.js'), 3000);
+  const importDelayed = () => import('./delayed.js');
+
+  if ('requestIdleCallback' in window) {
+    // prevents INP/TBT issues by only loading when CPU has capacity
+    window.requestIdleCallback(importDelayed);
+  } else {
+    window.setTimeout(importDelayed, 3000); // fallback 3-second timeout
+  }
   // load anything that can be postponed to the latest here
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -143,7 +143,7 @@ function loadDelayed() {
 
   if ('requestIdleCallback' in window) {
     // prevents INP/TBT issues by only loading when CPU has capacity
-    window.requestIdleCallback(importDelayed);
+    window.requestIdleCallback(importDelayed, { timeout: 3000 });
   } else {
     window.setTimeout(importDelayed, 3000); // fallback 3-second timeout
   }


### PR DESCRIPTION
Addresses discussion in #583 and relates to #376 and #408

This PR implements the `requestIdleCallback` approach proposed by @ramboz in discussion #583.

## Changes

- Modified `loadDelayed()` to use `requestIdleCallback` when available
- Loads delayed scripts only when CPU has spare capacity or falls back to existing 3-second `setTimeout` for browsers without support ([only ~82% coverage](https://caniuse.com/?search=requestIdleCallback) as of this comment)
- Prevents INP and TBT issues

## Benefits

- **Better performance**: No artificial delays or user interaction requirements
- **Predictable behavior**: Loads for all visitors
- **Progressive enhancement**: Modern browsers get optimal loading, older browsers get current behavior
- **Non-breaking**: Consent handling remains separate, scripts in delayed.js unaffected

Test URLs:
- Before: https://main--aem-boilerplate--adobe.aem.live/
- After: https://idle-delayed-loading--aem-boilerplate--adobe.aem.live/