### PR TITLE
perf(scripts): replace window.innerWidth with matchMedia to avoid forced reflow

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -142,7 +142,7 @@ async function loadEager(doc) {
 
   try {
     /* if desktop (proxy for fast connection) or fonts already loaded, load fonts.css */
-    if (window.innerWidth >= 900 || sessionStorage.getItem('fonts-loaded')) {
+    if (window.matchMedia('(min-width: 900px)').matches || sessionStorage.getItem('fonts-loaded')) {
       loadFonts();
     }
   } catch (e) {


### PR DESCRIPTION
## Summary

- Replaces `window.innerWidth >= 900` with `window.matchMedia('(min-width: 900px)').matches` in the eager load path of `scripts.js`
- `window.innerWidth` forces a synchronous layout reflow; `matchMedia` reads from the pre-computed style state and does not

## Why

Lighthouse / Chrome DevTools flags `window.innerWidth` as a forced-reflow source. See: https://developer.chrome.com/docs/performance/insights/forced-reflow

While i'm not convinced it's a real problem, I can envision scenarios where it could be, and I see no downside to eliminating the warning. 

## Preview

https://avoid-forced-reflow--aem-boilerplate--adobe.aem.live


🤖 Generated with [Claude Code](https://claude.com/claude-code)