### PR TITLE
fix(regression): revert aem.js update to v3.1.0

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -471,6 +471,24 @@ function decorateSections(main) {
     section.classList.add('section');
     section.dataset.sectionStatus = 'initialized';
     section.style.display = 'none';
+
+    // Process section metadata
+    const sectionMeta = section.querySelector('div.section-metadata');
+    if (sectionMeta) {
+      const meta = readBlockConfig(sectionMeta);
+      Object.keys(meta).forEach((key) => {
+        if (key === 'style') {
+          const styles = meta.style
+            .split(',')
+            .filter((style) => style)
+            .map((style) => toClassName(style.trim()));
+          styles.forEach((style) => section.classList.add(style));
+        } else {
+          section.dataset[toCamelCase(key)] = meta[key];
+        }
+      });
+      sectionMeta.parentNode.remove();
+    }
   });
 }
 


### PR DESCRIPTION
Reverts #616 which updated `scripts/aem.js` to aem.js@3.1.0.

The update removed the section metadata processing block from `decorateSections()`, which handles `div.section-metadata` — applying style classes, setting data attributes, and removing the element. This is a regression.

**Preview:** https://revert-pr-616--aem-boilerplate--adobe.aem.page/