### PR TITLE
fix(regression): restore aem.js v3.1.1

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -97,7 +97,7 @@ function sampleRUM(checkpoint, data) {
           const rumData = JSON.stringify({
             weight,
             id,
-            referer: window.location.origin + window.location.pathname,
+            referer: window.location.href,
             checkpoint: ck,
             t: time,
             ...pingData,
@@ -471,6 +471,24 @@ function decorateSections(main) {
     section.classList.add('section');
     section.dataset.sectionStatus = 'initialized';
     section.style.display = 'none';
+
+    // Process section metadata
+    const sectionMeta = section.querySelector('div.section-metadata');
+    if (sectionMeta) {
+      const meta = readBlockConfig(sectionMeta);
+      Object.keys(meta).forEach((key) => {
+        if (key === 'style') {
+          const styles = meta.style
+            .split(',')
+            .filter((style) => style)
+            .map((style) => toClassName(style.trim()));
+          styles.forEach((style) => section.classList.add(style));
+        } else {
+          section.dataset[toCamelCase(key)] = meta[key];
+        }
+      });
+      sectionMeta.parentNode.remove();
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Reverts merge commit b730fd5 (PR #623).
- Despite that PR's title ("update scripts/aem.js to aem.js@3.1.1"), the merge actually removed the v3.1.1 code from `scripts/aem.js`.
- This PR restores v3.1.1.

## Preview
https://revert-aem-3-1-1--aem-boilerplate--adobe.aem.page/

## Test plan
- [ ] Confirm `scripts/aem.js` on the preview matches v3.1.1
- [ ] Smoke-test the homepage on the preview URL above

🤖 Generated with Claude Code