### PR TITLE
feat: Harden CSP protection with Trusted Types

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,8 +1,8 @@
 <meta
   http-equiv="Content-Security-Policy"
-  content="script-src 'nonce-aem' 'strict-dynamic' 'unsafe-inline' http: https:; base-uri 'self'; object-src 'none';"
+  content="script-src 'nonce-aem' 'strict-dynamic' 'unsafe-inline' http: https:; base-uri 'self'; object-src 'none'; frame-src 'self' https:; require-trusted-types-for 'script';"
   move-to-http-header="true"
->
+/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script nonce="aem" src="/scripts/aem.js" type="module"></script>
 <script nonce="aem" src="/scripts/scripts.js" type="module"></script>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -12,6 +12,64 @@ import {
   buildBlock,
 } from './aem.js';
 
+if (window.trustedTypes && window.trustedTypes.createPolicy) {
+  const innerTT = window.trustedTypes.createPolicy('tt-inner', {
+    // avoid stack overflow
+    createHTML: (s) => s,
+  });
+
+  window.trustedTypes.createPolicy('default', {
+    /**
+     * All HTML creation goes through this function, so we can sanitize it for known attack vectors.
+     * @param {string} input The HTML input string
+     * @param {string} type The type of HTML being created
+     * @param {string} sink The sink where the HTML will be used
+     * @returns {undefined|string} The sanitized HTML string or undefined if the input is unsafe
+     */
+    createHTML: (input, type, sink) => {
+      // DOMPurify or similar sanitization library may be implemented here
+      // if a harder policy is desired, with a tradeoff on performance.
+      let processedInput = input;
+      if (/srcdoc\s*=/i.test(processedInput)) {
+        const doc = new DOMParser().parseFromString(innerTT.createHTML(processedInput), 'text/html');
+        doc.querySelectorAll('[srcdoc]').forEach((el) => el.removeAttribute('srcdoc'));
+        processedInput = doc.body.innerHTML;
+      }
+
+      if (sink.includes('createContextualFragment') || sink.includes('Document write')) {
+        const doc = new DOMParser().parseFromString(innerTT.createHTML(processedInput), 'text/html');
+        doc.querySelectorAll('script').forEach((el) => el.remove());
+        processedInput = doc.body.innerHTML;
+      }
+      return processedInput;
+    },
+
+    /**
+     * All script URL creation goes through this function,
+     * so we can sanitize it for known attack vectors.
+     * @param {string} input The script URL input string
+     * @returns {string} The sanitized script URL string
+     */
+    createScriptURL(input) {
+      // a trusted origin allowlist approach may be implemented here if a harder policy is desired
+      return input;
+    },
+
+    /**
+     * All script creation goes through this function,
+     * so we can sanitize it for known attack vectors.
+     * @param {string} input The script input string
+     * @returns {string} The sanitized script string
+     */
+    createScript(input) {
+      // Uncomment to block eval and script.text= assignments entirely
+      // (needs testing with your website code and martech stack):
+      // throw new TypeError('Inline script execution blocked by policy');
+      return input;
+    },
+  });
+}
+
 /**
  * load fonts.css and set a session storage flag
  */

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -22,7 +22,7 @@ if (window.trustedTypes && window.trustedTypes.createPolicy) {
       let processedInput = input;
       if (/srcdoc\s*=/i.test(processedInput)) {
         const doc = new DOMParser().parseFromString(innerTT.createHTML(processedInput), 'text/html');
-        doc.querySelectorAll('[srcdoc]').forEach((el) => el.removeAttribute('srcdoc'));
+        doc.querySelectorAll('iframe[srcdoc]').forEach((el) => el.removeAttribute('srcdoc'));
         processedInput = doc.body.innerHTML;
       }
       if (sink.includes('createContextualFragment') || sink.includes('Document write')) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,28 +14,17 @@ import {
 
 if (window.trustedTypes && window.trustedTypes.createPolicy) {
   const innerTT = window.trustedTypes.createPolicy('tt-inner', {
-    // avoid stack overflow
-    createHTML: (s) => s,
+    createHTML: (s) => s, // avoid stack overflow
   });
 
   window.trustedTypes.createPolicy('default', {
-    /**
-     * All HTML creation goes through this function, so we can sanitize it for known attack vectors.
-     * @param {string} input The HTML input string
-     * @param {string} type The type of HTML being created
-     * @param {string} sink The sink where the HTML will be used
-     * @returns {undefined|string} The sanitized HTML string or undefined if the input is unsafe
-     */
     createHTML: (input, type, sink) => {
-      // DOMPurify or similar sanitization library may be implemented here
-      // if a harder policy is desired, with a tradeoff on performance.
       let processedInput = input;
       if (/srcdoc\s*=/i.test(processedInput)) {
         const doc = new DOMParser().parseFromString(innerTT.createHTML(processedInput), 'text/html');
         doc.querySelectorAll('[srcdoc]').forEach((el) => el.removeAttribute('srcdoc'));
         processedInput = doc.body.innerHTML;
       }
-
       if (sink.includes('createContextualFragment') || sink.includes('Document write')) {
         const doc = new DOMParser().parseFromString(innerTT.createHTML(processedInput), 'text/html');
         doc.querySelectorAll('script').forEach((el) => el.remove());
@@ -43,30 +32,8 @@ if (window.trustedTypes && window.trustedTypes.createPolicy) {
       }
       return processedInput;
     },
-
-    /**
-     * All script URL creation goes through this function,
-     * so we can sanitize it for known attack vectors.
-     * @param {string} input The script URL input string
-     * @returns {string} The sanitized script URL string
-     */
-    createScriptURL(input) {
-      // a trusted origin allowlist approach may be implemented here if a harder policy is desired
-      return input;
-    },
-
-    /**
-     * All script creation goes through this function,
-     * so we can sanitize it for known attack vectors.
-     * @param {string} input The script input string
-     * @returns {string} The sanitized script string
-     */
-    createScript(input) {
-      // Uncomment to block eval and script.text= assignments entirely
-      // (needs testing with your website code and martech stack):
-      // throw new TypeError('Inline script execution blocked by policy');
-      return input;
-    },
+    createScriptURL: (input) => input,
+    createScript: (input) => input,
   });
 }
 


### PR DESCRIPTION
Fix [SITES-46900](https://jira.corp.adobe.com/browse/SITES-46900) -> We can use the JIRA for internal conversations

Test URLs:
- Before: https://main--aem-boilerplate--adobe.aem.live/
- After: https://csp-update--aem-boilerplate--adobe.aem.live/

# Changes

1. Add `frame-src` directive to the CSP -> make sure that the src attribute of iframes can only be a `https:` url or self, so `data:` protocols and similar are deactivated.
2. Enable trusted types, the new baseline feature for browsers: https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API 
3. Create a default Trusted Types policy which helps cover remaining DOM based edge cases that cannot be covered with the cached nonce approach.