### PR TITLE
fix: align CSS indent_size in .editorconfig with actual code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,4 +2,4 @@
 indent_size = 2
 
 [*.css]
-indent_size = 4
+indent_size = 2


### PR DESCRIPTION
## Problem

The `.editorconfig` added in #353 declares `indent_size = 4` for CSS files, but all CSS shipped in this repository uses 2-space indentation — e.g. `styles/styles.css`, `blocks/header/header.css`, `blocks/footer/footer.css`.

Since every Edge Delivery project is bootstrapped from this template, the mismatch propagates: any editorconfig-aware editor with format-on-save (VS Code + Prettier is a common setup) mass-reformats touched CSS files to 4-space indents, producing large whitespace-only diffs. Stylelint no longer checks indentation (`stylelint-config-standard` dropped formatting rules in v15), so nothing catches this.

Judging by the discussion in #353, the intent was consistency across editors — the `4` for CSS appears to be an oversight rather than a deliberate choice, since it contradicts the repository's own code.

## Fix

Set CSS `indent_size` to `2`, matching the JS setting and the existing CSS files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)