### PR TITLE
fix(widget): apply shell config before widget hydration

### DIFF
--- a/blocks/widget/widget.js
+++ b/blocks/widget/widget.js
@@ -24,6 +24,34 @@ function widgetUrl(widgetPath, widgetName, extension) {
 }
 
 /**
+ * Applies widget metadata, block classes, and section shell classes.
+ * Must run before widget HTML/JS load so decorate can read config from the DOM.
+ * @param {Element} widget The widget block element
+ * @param {HTMLAnchorElement} source The authored widget link
+ * @param {string} widgetName Widget file name without extension
+ * @param {URLSearchParams} searchParams Query params from the widget href
+ */
+function applyWidgetShell(widget, source, widgetName, searchParams) {
+  widget.classList.add(widgetName);
+  widget.classList.remove('block');
+  widget.dataset.source = source.href;
+  searchParams.forEach((value, key) => {
+    widget.dataset[key] = value;
+  });
+
+  const wrapper = widget.closest('.widget-wrapper');
+  if (wrapper) {
+    wrapper.classList.add(`${widgetName}-wrapper`);
+    wrapper.classList.remove('widget-wrapper');
+  }
+  const container = widget.closest('.widget-container');
+  if (container) {
+    container.classList.add(`${widgetName}-container`);
+    container.classList.remove('widget-container');
+  }
+}
+
+/**
  * Loads and decorates a widget block.
  * @param {Element} widget The widget block element
  */
@@ -33,6 +61,8 @@ export default async function decorate(widget) {
   const { widgetPath, widgetName } = parseWidgetHref(pathname);
 
   try {
+    applyWidgetShell(widget, source, widgetName, searchParams);
+
     const resp = await fetch(widgetUrl(widgetPath, widgetName, 'html'));
     widget.innerHTML = await resp.text();
 
@@ -42,24 +72,6 @@ export default async function decorate(widget) {
       if (mod.default) await mod.default(widget);
     })();
     await Promise.all([cssLoaded, decorationComplete]);
-
-    widget.classList.add(widgetName);
-    widget.classList.remove('block');
-    widget.dataset.source = source.href;
-    searchParams.forEach((value, key) => {
-      widget.dataset[key] = value;
-    });
-
-    const wrapper = widget.closest('.widget-wrapper');
-    if (wrapper) {
-      wrapper.classList.add(`${widgetName}-wrapper`);
-      wrapper.classList.remove('widget-wrapper');
-    }
-    const container = widget.closest('.widget-container');
-    if (container) {
-      container.classList.add(`${widgetName}-container`);
-      container.classList.remove('widget-container');
-    }
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(`failed to load widget ${widgetPath}/${widgetName}`, error);


### PR DESCRIPTION
## Summary

- Reorders widget block decoration so metadata, block classes, and wrapper/container shell classes are applied before fetching widget HTML and loading widget JS
- Extracts shell setup into `applyWidgetShell()` so widgets can read `dataset`, name classes, and parent selectors during their decorate function

## Context

Previously the block followed a "hydrate first, attach metadata and shell classes after" pattern. That works for widgets that don't need config at decorate time, but breaks widgets that read query-param `data-*` attributes, widget name classes, or `{name}-wrapper` / `{name}-container` parents when they initialize.

## Test plan

- [ ] Add or use a widget whose `decorate()` reads `el.dataset` or parent shell classes
- [ ] Author a page with a widget link including query params (e.g. `/widgets/demo/demo.html?theme=dark`)
- [ ] Verify config is available when the widget decorate function runs
- [ ] Verify resulting DOM still has correct `{name}`, `{name}-wrapper`, and `{name}-container` classes after load
- [ ] Preview: https://fix-widget-shell-before-hydrate--aem-boilerplate--adobe.aem.page/


Made with [Cursor](https://cursor.com)