### PR TITLE
fix: scope header/footer selectors to body-level elements

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -184,7 +184,7 @@ async function loadEager(doc) {
  * @param {Element} doc The container element
  */
 async function loadLazy(doc) {
-  loadHeader(doc.querySelector('header'));
+  loadHeader(doc.querySelector('body > header'));
 
   const main = doc.querySelector('main');
   await loadSections(main);
@@ -193,7 +193,7 @@ async function loadLazy(doc) {
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
-  loadFooter(doc.querySelector('footer'));
+  loadFooter(doc.querySelector('body > footer'));
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();


### PR DESCRIPTION
Test URLs:
- Before: https://main--aem-boilerplate--adobe.aem.live/
- After:  https://scope-header-footer-selectors--aem-boilerplate--adobe.aem.live/
