### PR TITLE
feat: gate delayed scripts behind a consent check

### DIFF
--- a/scripts/consent-check.js
+++ b/scripts/consent-check.js
@@ -1,0 +1,46 @@
+let consentedLoaded = false;
+
+/**
+ * Dummy consent implementation.
+ *
+ * By default consent is declined, so consented scripts (analytics, martech, etc.)
+ * are not loaded. This stands in for a real CMP (OneTrust, etc.) and can be
+ * swapped out later.
+ *
+ * The default can be overridden with a query parameter for testing:
+ *   ?consent=accept   grant consent (loads consented.js)
+ *   ?consent=decline  decline consent (default behavior)
+ *
+ * @returns {boolean} true if the user has consented
+ */
+function hasConsent() {
+  const consent = new URLSearchParams(window.location.search).get('consent');
+  if (consent !== null) {
+    return ['accept', 'true', '1', 'yes'].includes(consent.toLowerCase());
+  }
+  // default: decline
+  return false;
+}
+
+/**
+ * Loads consented scripts once consent is available.
+ */
+function loadConsented() {
+  if (consentedLoaded) return;
+  consentedLoaded = true;
+  import('./consented.js');
+}
+
+/**
+ * Notifies listeners of the current consent state and loads consented
+ * scripts if consent has been granted.
+ */
+function onConsentUpdate() {
+  const consented = hasConsent();
+  window.dispatchEvent(new CustomEvent('consent.update', { detail: { consented } }));
+  if (consented) {
+    loadConsented();
+  }
+}
+
+onConsentUpdate();

--- a/scripts/consented.js
+++ b/scripts/consented.js
@@ -1,0 +1,1 @@
+// add functionality that requires user consent here (analytics, martech, etc.)

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,1 +1,0 @@
-// add delayed functionality here

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -204,8 +204,7 @@ async function loadLazy(doc) {
  * without impacting the user experience.
  */
 function loadDelayed() {
-  // eslint-disable-next-line import/no-cycle
-  window.setTimeout(() => import('./delayed.js'), 3000);
+  import('./consent-check.js');
   // load anything that can be postponed to the latest here
 }
 


### PR DESCRIPTION
## What

Replaces the `delayed.js` load with a consent-check step in the delayed loading phase. Consented scripts (analytics, martech, etc.) now live in `consented.js` and are only loaded once consent is granted.

## Changes

- `scripts/scripts.js` — `loadDelayed()` now imports `consent-check.js` instead of `delayed.js`.
- `scripts/consent-check.js` (new) — dummy consent implementation standing in for a real CMP (OneTrust, etc.). **Declines by default**, dispatches a `consent.update` event, and loads `consented.js` only when consent is granted.
- `scripts/consented.js` (new) — placeholder for consent-gated scripts.
- `scripts/delayed.js` — removed (no longer referenced).

## Testing / override

The dummy declines by default. Override via query param to exercise the consented path:

- `?consent=accept` (also `true` / `1` / `yes`) — grants consent, loads `consented.js`
- `?consent=decline` — explicit decline (same as default)

Preview: https://feat-consent-check--aem-boilerplate--adobe.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)