### PR TITLE
fix: give fragment blocks proper top-level section styling

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -46,5 +46,19 @@ export default async function decorate(block) {
   const link = block.querySelector('a');
   const path = link ? link.getAttribute('href') : block.textContent.trim();
   const fragment = await loadFragment(path);
-  if (fragment) block.replaceChildren(...fragment.childNodes);
+  if (!fragment) return;
+
+  const wrapper = block.closest('.fragment-wrapper');
+  const section = wrapper.closest('.section');
+
+  if (section && section.children.length === 1) {
+    // fragment is the ONLY child of its section; replace the whole section
+    section.replaceWith(...fragment.childNodes);
+  } else {
+    // fragment shares section with other children; flatten children into it
+    fragment.querySelectorAll(':scope > .section').forEach((fragSection) => {
+      [...fragSection.childNodes].forEach((child) => wrapper.before(child));
+    });
+    wrapper.remove();
+  }
 }


### PR DESCRIPTION
`decorate()` nested the fragment's own section inside `.fragment.block`, so it never counted as a direct child of `main`. 

_Fix_: if the fragment is the only thing in its host section, promote its section(s) to real top-level sections. Otherwise, flatten them into the shared section (now handles multiple fragment sections, not just the first).

Test URLs:
- Before: https://main--aem-boilerpalte--adobe.aem.live/
- After: https://fragment-nesting--aem-boilerplate--adobe.aem.live/
