### PR TITLE
fix: ignore sync-block-collection.sh in .hlxignore

### DIFF
--- a/.hlxignore
+++ b/.hlxignore
@@ -5,3 +5,4 @@ LICENSE
 package.json
 package-lock.json
 test/*
+sync-block-collection.sh


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Test URLs:
- Before: https://main--aem-boilerplate--adobe.aem.live/
- After: https://hlxignore-fix--aem-boilerplate--adobe.aem.live/
